### PR TITLE
각 환경에서 사용할 yml 설정파일을 분리한다. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ out/
 ### YML ###
 application-dev.yml
 application-local.yml
+application-prod.yml

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### YML ###
+application-dev.yml
+application-local.yml

--- a/build.gradle
+++ b/build.gradle
@@ -21,8 +21,13 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
+    // mysql
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    // h2
+    runtimeOnly 'com.h2database:h2'
+
+    // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,3 @@
 spring:
-  datasource:
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    url: ${MYSQL_URL}
-    username: ${MYSQL_USERNAME}
-    password: ${MYSQL_PASSWORD}
+  profiles:
+    active: local


### PR DESCRIPTION
## Issue
* [x] #4 

## 변경점
* application-local, application-dev, application-prod 파일로 각각 분리
* 위의 파일은 github에서 드러내지 않을 것이기 때문에 .gitignore 파일에 추가
* local 환경에서는 h2 db를 사용할 것이기 때문에 gradle에 h2 의존성을 추가

This closes #4 